### PR TITLE
Version 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: php
 
 php:
-  - 7.2
   - 7.3
   - 7.4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
-sudo: false
-
 language: php
 
 php:
   - 7.3
   - 7.4
+  - 8.0snapshot
 
 before_script:
   - travis_retry composer self-update

--- a/README.md
+++ b/README.md
@@ -24,15 +24,18 @@ Breadcrumbs::for('home', function () {
 });
 
 Breadcrumbs::for('users.index', function () {
-    $this->extends('home')->then('Users', route('users.index'));
+    $this->extends('home')
+        ->then('Users', route('users.index'));
 });
 
 Breadcrumbs::for('users.show', function (User $user) {
-    $this->extends('users.index')->then($user->full_name, route('users.show', $user));
+    $this->extends('users.index')
+        ->then($user->full_name, route('users.show', $user));
 });
 
 Breadcrumbs::for('users.edit', function (User $user) {
-    $this->extends('users.show', $user)->then($user->full_name, route('users.show', $user));
+    $this->extends('users.show', $user)
+        ->then($user->full_name, route('users.show', $user));
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ In your view file, you simply need to call the `render()` method wherever you wa
 {{ Breadcrumbs::render() }}
 ```
 
+Alternatively, you can specify the route name and pass in the arguments for a specific breadcrumb.
+
+```php
+{{ Breadcrumbs::render('users.show', [Auth::user()]) }}
+```
+
 ### Customising the breadcrumb view
 
 The package ships with a Bootstrap 3 compatible view which you can publish and customise as you need, or override completely with your own view. Simply run the following command to publish the view.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Breadcrumbs for Laravel
 [![Total Downloads](https://poser.pugx.org/watson/breadcrumbs/downloads.svg)](https://packagist.org/packages/watson/breadcrumbs)
 [![License](https://poser.pugx.org/watson/breadcrumbs/license.svg)](https://packagist.org/packages/watson/breadcrumbs)
 
-Breadcrumbs is a simple breadcrumb generator for Laravel that tries to hook into the magic to make it easy to get up and running.
+Breadcrumbs is a simple breadcrumb generator for Laravel that tries to hook into the magic to make it easy to get up and running. It ships with support for Bootstrap 3 and 4 (with 4 the default) but it's easy to drop in your own view instead.
 
 ## Installation
 
@@ -20,49 +20,24 @@ $ composer require watson/breadcrumbs
 Create a new file at `routes/breadcrumbs.php` to define your breadcrumbs. By default the package will work with named routes which works with resourceful routing. However, you're also free to define routes by the controller action/pair.
 
 ```php
-Breadcrumbs::for('admin.pages.index', function ($trail) {
-    $trail->add('Admin', route('admin.pages.index'));
+Breadcrumbs::for('home', function () {
+    $this->then('Home', route('home'));
 });
 
-Breadcrumbs::for('admin.users.index', function ($trail) {
-    $trail->parent('admin.pages.index');
-    $trail->add('Users', route('admin.users.index'));
+Breadcrumbs::for('users.index', function () {
+    $this->extends('home')->then('Users', route('users.index'));
 });
 
-Breadcrumbs::for('admin.users.show', function ($trail, User $user) {
-    $trail->parent('admin.users.index');
-    $trail->add($user->full_name, route('admin.users.show', $user));
+Breadcrumbs::for('users.show', function (User $user) {
+    $this->extends('users.index')->then($user->full_name, route('users.show', $user));
 });
 
-Breadcrumbs::for('admin.users.edit', function ($trail, User $user) {
-    $trail->parent('admin.users.show', $user);
-    $trail->add('Edit', route('admin.users.edit', $user));
-});
-
-Breadcrumbs::for('admin.users.roles.index', function ($trail, User $user) {
-    $trail->parent('admin.users.show', $user);
-    $trail->add('Roles', route('admin.users.roles.index', $user));
-});
-
-Breadcrumbs::for('admin.users.roles.show', function ($trail, User $user, Role $role) {
-    $trail->parent('admin.users.roles.index', $user, $role);
-    $trail->add('Edit', route('admin.users.roles.show', [$user, $role]));
+Breadcrumbs::for('users.edit', function (User $user) {
+    $this->extends('users.show', $user)->then($user->full_name, route('users.show', $user));
 });
 ```
 
-Note that you can call `parent()` from within a breadcrumb definition which lets you build up the breadcrumb tree. Pass any parameters you need further up through the second parameter.
-
-If you want to use controller/action pairs instead of named routes that's fine too. Use the usual Laravel syntax and the package will correctly map it up for you. Note that if the route is named the package will always looked for a named breadcrumb first.
-
-```php
-Breadcrumbs::for('PagesController@getIndex', function ($trail) {
-    $trail->add('Home', action('PagesController@getIndex'));
-});
-
-Breadcrumbs::for('secret.page', function ($trail) {
-    $trail->add('Secret page', url('secret'))
-});
-```
+Note that you can call `extends()` from within a breadcrumb definition which lets you build up the breadcrumb tree. Pass any parameters you need further up through the second parameter.
 
 ### Rendering the breadcrumbs
 
@@ -70,16 +45,6 @@ In your view file, you simply need to call the `render()` method wherever you wa
 
 ```php
 {{ Breadcrumbs::render() }}
-```
-
-You don't need to escape the content of the breadcrumbs, it's already wrapped in an instance of `Illuminate\Support\HtmlString` so Laravel knows just how to use it.
-
-### Multiple breadcrumb files
-
-If you find that your breadcrumbs files is starting to get a little bigger you may like to break it out into multiple, smaller files. If that's the case you can simply `require` other breadcrumb files at the top of your default definition file.
-
-```php
-require 'breadcrumbs.admin.php';
 ```
 
 ### Customising the breadcrumb view
@@ -90,7 +55,7 @@ The package ships with a Bootstrap 3 compatible view which you can publish and c
 $ php artisan vendor:publish --provider="Watson\Breadcrumbs\ServiceProvider" --tag=views
 ```
 
-This will publish the default `bootstrap3` view to your `resources/views/vendor/breadcrumbs` directory from which you can edit the file to your heart's content. If you want to use your own view instead, run the following command to publish the config file.
+This will publish the default `bootstrap4` view to your `resources/views/vendor/breadcrumbs` directory from which you can edit the file to your heart's content. If you want to use your own view instead, run the following command to publish the config file.
 
 ```sh
 $ php artisan vendor:publish --provider="Watson\Breadcrumbs\ServiceProvider" --tag=config

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3||^8.0",
         "illuminate/routing": "^8.0",
         "illuminate/support": "^8.0",
         "illuminate/view": "^8.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.3.1",
+        "mockery/mockery": "^1.4.2",
         "phpunit/phpunit": "^9.0",
         "orchestra/testbench": "^6.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,10 @@
 {
     "name": "watson/breadcrumbs",
     "description": "Breadcrumbs made easy for Laravel.",
-    "keywords": ["laravel", "breadcrumbs"],
+    "keywords": [
+        "laravel",
+        "breadcrumbs"
+    ],
     "license": "MIT",
     "authors": [
         {
@@ -10,14 +13,15 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
-        "illuminate/routing": "^7.0|^8.0",
-        "illuminate/support": "^7.0|^8.0",
-        "illuminate/view": "^7.0|^8.0"
+        "php": "^7.3",
+        "illuminate/routing": "^8.0",
+        "illuminate/support": "^8.0",
+        "illuminate/view": "^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.0",
+        "orchestra/testbench": "^6.1"
     },
     "autoload": {
         "psr-4": {
@@ -35,7 +39,8 @@
                 "Watson\\Breadcrumbs\\ServiceProvider"
             ],
             "aliases": {
-                "Breadcrumbs": "Watson\\Breadcrumbs\\Facade"
+                "Breadcrumbs": "Watson\\Breadcrumbs\\Facades\\Breadcrumbs",
+                "Trail": "Watson\\Breadcrumbs\\Facades\\Trail"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "illuminate/routing": "^7.0",
-        "illuminate/support": "^7.0",
-        "illuminate/view": "^7.0"
+        "illuminate/routing": "^7.0|^8.0",
+        "illuminate/support": "^7.0|^8.0",
+        "illuminate/view": "^7.0|^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",

--- a/src/Breadcrumbs/Facades/Breadcrumbs.php
+++ b/src/Breadcrumbs/Facades/Breadcrumbs.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Watson\Breadcrumbs;
+namespace Watson\Breadcrumbs\Facades;
 
-use Illuminate\Support\Facades\Facade as BaseFacade;
+use Illuminate\Support\Facades\Facade;
 
-class Facade extends BaseFacade
+class Breadcrumbs extends Facade
 {
     /**
      * Get the registered name of the component.
@@ -13,6 +13,6 @@ class Facade extends BaseFacade
      */
     protected static function getFacadeAccessor()
     {
-        return 'breadcrumbs';
+        return 'breadcrumbs.manager';
     }
 }

--- a/src/Breadcrumbs/Facades/Trail.php
+++ b/src/Breadcrumbs/Facades/Trail.php
@@ -3,6 +3,7 @@
 namespace Watson\Breadcrumbs\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Watson\Breadcrumbs\Generator;
 
 class Trail extends Facade
 {
@@ -13,6 +14,6 @@ class Trail extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'breadcrumbs.generator';
+        return Generator::class;
     }
 }

--- a/src/Breadcrumbs/Facades/Trail.php
+++ b/src/Breadcrumbs/Facades/Trail.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Watson\Breadcrumbs\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class Trail extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'breadcrumbs.generator';
+    }
+}

--- a/src/Breadcrumbs/Generator.php
+++ b/src/Breadcrumbs/Generator.php
@@ -76,13 +76,13 @@ class Generator
     }
 
     /**
-     * Call a parent route with the given parameters.
+     * Call a extends route with the given parameters.
      *
      * @param  string  $name
      * @param  mixed  $parameters
      * @return void
      */
-    public function parent(string $name, ...$parameters)
+    public function extends(string $name, ...$parameters)
     {
         $this->call($name, $parameters);
     }
@@ -94,7 +94,7 @@ class Generator
      * @param  string  $url
      * @return void
      */
-    public function add(string $title, string $url)
+    public function then(string $title, string $url)
     {
         $this->breadcrumbs->push(new Crumb($title, $url));
     }
@@ -111,8 +111,8 @@ class Generator
     {
         $definition = $this->registrar->get($name);
 
-        $parameters = Arr::prepend(array_values($parameters), $this);
+        $definition->bindTo($this);
 
-        call_user_func_array($definition, $parameters);
+        $definition(...$parameters);
     }
 }

--- a/src/Breadcrumbs/Generator.php
+++ b/src/Breadcrumbs/Generator.php
@@ -4,7 +4,6 @@ namespace Watson\Breadcrumbs;
 
 use Closure;
 use Illuminate\Contracts\Routing\Registrar as Router;
-use Illuminate\Routing\Route;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
@@ -54,12 +53,10 @@ class Generator
      *
      * @return \Illuminate\Support\Collection
      */
-    public function generate(?Route $route): Collection
+    public function generate(string $name, ?array $parameters = []): Collection
     {
-        $parameters = $route->parameters;
-
-        if ($route && $this->registrar->has($route->getName())) {
-            $this->call($route->getName(), $parameters);
+        if ($this->registrar->has($name)) {
+            $this->call($name, $parameters);
         }
 
         return $this->breadcrumbs;

--- a/src/Breadcrumbs/Manager.php
+++ b/src/Breadcrumbs/Manager.php
@@ -11,13 +11,17 @@ class Manager
 {
     /**
      * The breadcrumb generator.
+     *
+     * @var \Watson\Breadcrumbs\Generator
      */
-    protected Generator $generator;
+    protected $generator;
 
     /**
      * The breadcrumb renderer.
+     *
+     * @var \Watson\Breadcrumbs\Renderer
      */
-    protected Renderer $renderer;
+    protected $renderer;
 
     /**
      * Create the instance of the manager.

--- a/src/Breadcrumbs/Manager.php
+++ b/src/Breadcrumbs/Manager.php
@@ -52,15 +52,21 @@ class Manager
      *
      * @return  \Illuminate\Contracts\Support\Htmlable
      */
-    public function render(): ?Htmlable
+    public function render(?string $name = null, ?array $parameters = []): ?Htmlable
     {
         $route = $this->router->current();
 
-        if (is_null($route) || is_null($route->getName())) {
+        $name = $name ?: $route->getName();
+
+        if (is_null($name)) {
             return $this->renderer->render(collect());
         }
 
-        $breadcrumbs = $this->generator->generate($route);
+        $parameters = Arr::wrap(
+            $parameters ?: $route->parameters
+        );
+
+        $breadcrumbs = $this->generator->generate($name, $parameters);
 
         return $this->renderer->render($breadcrumbs);
     }

--- a/src/Breadcrumbs/Renderer.php
+++ b/src/Breadcrumbs/Renderer.php
@@ -21,7 +21,7 @@ class Renderer
      *
      * @var \Illuminate\Contracts\Config\Repository
      */
-    protected Repository $config;
+    protected $config;
 
     /**
      * Create a new renderer instance.

--- a/src/Breadcrumbs/Renderer.php
+++ b/src/Breadcrumbs/Renderer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Watson\Breadcrumbs;
+
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Support\Collection;
+
+class Renderer
+{
+    /**
+     * The view factory.
+     */
+    protected Factory $view;
+
+    /**
+     * The config repository.
+     */
+    protected Repository $config;
+
+    /**
+     * Create a new renderer instance.
+     *
+     * @return void
+     */
+    public function __construct(Factory $view, Repository $config)
+    {
+        $this->view = $view;
+        $this->config = $config;
+    }
+
+    /**
+     * Render the given breadcrumbs if any are provided.
+     */
+    public function render(Collection $breadcrumbs): ?Htmlable
+    {
+        return $this->view->make($this->config->get('breadcrumbs.view'), compact('breadcrumbs'));
+    }
+}

--- a/src/Breadcrumbs/Renderer.php
+++ b/src/Breadcrumbs/Renderer.php
@@ -11,11 +11,15 @@ class Renderer
 {
     /**
      * The view factory.
+     *
+     * @var \Illuminate\Contracts\View\Factory
      */
-    protected Factory $view;
+    protected $view;
 
     /**
      * The config repository.
+     *
+     * @var \Illuminate\Contracts\Config\Repository
      */
     protected Repository $config;
 

--- a/src/Breadcrumbs/ServiceProvider.php
+++ b/src/Breadcrumbs/ServiceProvider.php
@@ -16,7 +16,7 @@ class ServiceProvider extends BaseServiceProvider implements DeferrableProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/breadcrumbs.php', 'breadcrumbs');
 
-        $this->app->singleton('breadcrumbs', Manager::class);
+        $this->app->singleton('breadcrumbs.manager', Manager::class);
     }
 
     /**
@@ -44,6 +44,6 @@ class ServiceProvider extends BaseServiceProvider implements DeferrableProvider
      */
     public function provides()
     {
-        return ['breadcrumbs'];
+        return ['breadcrumbs.manager'];
     }
 }

--- a/src/Breadcrumbs/ServiceProvider.php
+++ b/src/Breadcrumbs/ServiceProvider.php
@@ -17,6 +17,7 @@ class ServiceProvider extends BaseServiceProvider implements DeferrableProvider
         $this->mergeConfigFrom(__DIR__.'/../config/breadcrumbs.php', 'breadcrumbs');
 
         $this->app->singleton('breadcrumbs.manager', Manager::class);
+        $this->app->singleton(Generator::class);
     }
 
     /**

--- a/tests/Feature/BreadcrumbsTest.php
+++ b/tests/Feature/BreadcrumbsTest.php
@@ -28,6 +28,20 @@ class BreadcrumbsTest extends TestCase
     }
 
     /** @test */
+    public function it_renders_breadcrumb_for_the_given_route()
+    {
+        Route::get('/users/{user}')->name('users.show');
+
+        Breadcrumbs::for('users.show', function (string $user) {
+            $this->then($user, '/');
+        });
+
+        $breadcrumbs = Breadcrumbs::render('users.show', ['foo']);
+
+        $this->assertStringContainsString('foo', $breadcrumbs->render());
+    }
+
+    /** @test */
     public function it_renders_breadcrumb_for_the_current_route_with_facade()
     {
         Route::get('/')->name('home');
@@ -78,6 +92,28 @@ class BreadcrumbsTest extends TestCase
 
         $breadcrumbs = Breadcrumbs::render();
 
+        $this->assertStringContainsString('taylor', $breadcrumbs->render());
+    }
+
+    /** @test */
+    public function it_renders_nested_breadcrumbs()
+    {
+        Route::get('/')->name('home');
+        Route::get('/users/{user}')->name('users.show');
+
+        $this->call('GET', '/users/taylor');
+
+        Breadcrumbs::for('home', function () {
+            $this->then('Home', '/');
+        });
+
+        Breadcrumbs::for('users.show', function (string $user) {
+            $this->extends('home')->then($user, '/');
+        });
+
+        $breadcrumbs = Breadcrumbs::render();
+
+        $this->assertStringContainsString('Home', $breadcrumbs->render());
         $this->assertStringContainsString('taylor', $breadcrumbs->render());
     }
 

--- a/tests/Feature/BreadcrumbsTest.php
+++ b/tests/Feature/BreadcrumbsTest.php
@@ -7,6 +7,7 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Watson\Breadcrumbs\Facades\Breadcrumbs;
+use Watson\Breadcrumbs\Facades\Trail;
 
 class BreadcrumbsTest extends TestCase
 {
@@ -18,6 +19,20 @@ class BreadcrumbsTest extends TestCase
         $this->call('GET', '/');
 
         Breadcrumbs::for('home', fn () => $this->then('Home', '/'));
+
+        $breadcrumbs = Breadcrumbs::render();
+
+        $this->assertStringContainsString('Home', $breadcrumbs->render());
+    }
+
+    /** @test */
+    public function it_renders_breadcrumb_for_the_current_route_with_facade()
+    {
+        Route::get('/')->name('home');
+
+        $this->call('GET', '/');
+
+        Breadcrumbs::for('home', fn () => Trail::then('Home', '/'));
 
         $breadcrumbs = Breadcrumbs::render();
 

--- a/tests/Feature/BreadcrumbsTest.php
+++ b/tests/Feature/BreadcrumbsTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Watson\Breadcrumbs\Tests\Feature;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use Watson\Breadcrumbs\Facades\Breadcrumbs;
+
+class BreadcrumbsTest extends TestCase
+{
+    /** @test */
+    public function it_renders_breadcrumb_for_the_current_route()
+    {
+        Route::get('/')->name('home');
+
+        $this->call('GET', '/');
+
+        Breadcrumbs::for('home', fn () => $this->then('Home', '/'));
+
+        $breadcrumbs = Breadcrumbs::render();
+
+        $this->assertStringContainsString('Home', $breadcrumbs->render());
+    }
+
+    /** @test */
+    public function it_renders_breadcrumb_for_the_current_route_with_parameters()
+    {
+        Route::get('/users/{user}')->name('home');
+
+        $this->call('GET', '/users/taylor');
+
+        Breadcrumbs::for('home', fn (string $user) => $this->then($user, '/'));
+
+        $breadcrumbs = Breadcrumbs::render();
+
+        $this->assertStringContainsString('taylor', $breadcrumbs->render());
+    }
+
+    /** @test */
+    public function it_renders_breadcrumb_for_the_current_route_with_bound_paramters()
+    {
+        $this->loadLaravelMigrations();
+
+        DB::table('users')->insert(['name' => 'taylor', 'email' => 'taylor@example.com', 'password' => 'secret']);
+
+        Route::get('/users/{user}', function (User $user) {
+            //
+        })->middleware(SubstituteBindings::class)->name('home');
+
+        $this->call('GET', '/users/1');
+
+        Breadcrumbs::for('home', fn (User $user) => $this->then($user, '/'));
+
+        $breadcrumbs = Breadcrumbs::render();
+
+        $this->assertStringContainsString('taylor', $breadcrumbs->render());
+    }
+
+    /** @test */
+    public function it_does_not_render_breadcrumbs_without_named_route()
+    {
+        Route::get('/');
+
+        $this->call('GET', '/');
+
+        Breadcrumbs::for('home', fn () => $this->then('Home', '/'));
+
+        $breadcrumbs = Breadcrumbs::render();
+
+        $this->assertEquals('', $breadcrumbs->render());
+    }
+
+    /** @test */
+    public function it_does_not_render_breadcrumbs_without_matching_breadcrumb()
+    {
+        Route::get('/')->name('home');
+
+        $this->call('GET', '/');
+
+        $breadcrumbs = Breadcrumbs::render();
+
+        $this->assertEquals('', $breadcrumbs->render());
+    }
+}
+
+class User extends Model
+{
+    //
+}

--- a/tests/Feature/BreadcrumbsTest.php
+++ b/tests/Feature/BreadcrumbsTest.php
@@ -18,7 +18,9 @@ class BreadcrumbsTest extends TestCase
 
         $this->call('GET', '/');
 
-        Breadcrumbs::for('home', fn () => $this->then('Home', '/'));
+        Breadcrumbs::for('home', function () {
+            $this->then('Home', '/');
+        });
 
         $breadcrumbs = Breadcrumbs::render();
 
@@ -32,7 +34,9 @@ class BreadcrumbsTest extends TestCase
 
         $this->call('GET', '/');
 
-        Breadcrumbs::for('home', fn () => Trail::then('Home', '/'));
+        Breadcrumbs::for('home', function () {
+            Trail::then('Home', '/');
+        });
 
         $breadcrumbs = Breadcrumbs::render();
 
@@ -46,7 +50,9 @@ class BreadcrumbsTest extends TestCase
 
         $this->call('GET', '/users/taylor');
 
-        Breadcrumbs::for('home', fn (string $user) => $this->then($user, '/'));
+        Breadcrumbs::for('home', function (string $user) {
+            $this->then($user, '/');
+        });
 
         $breadcrumbs = Breadcrumbs::render();
 
@@ -66,7 +72,9 @@ class BreadcrumbsTest extends TestCase
 
         $this->call('GET', '/users/1');
 
-        Breadcrumbs::for('home', fn (User $user) => $this->then($user, '/'));
+        Breadcrumbs::for('home', function (User $user) {
+            $this->then($user, '/');
+        });
 
         $breadcrumbs = Breadcrumbs::render();
 
@@ -80,7 +88,9 @@ class BreadcrumbsTest extends TestCase
 
         $this->call('GET', '/');
 
-        Breadcrumbs::for('home', fn () => $this->then('Home', '/'));
+        Breadcrumbs::for('home', function () {
+            $this->then('Home', '/');
+        });
 
         $breadcrumbs = Breadcrumbs::render();
 

--- a/tests/Feature/TestCase.php
+++ b/tests/Feature/TestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Watson\Breadcrumbs\Tests\Feature;
+
+use Orchestra\Testbench\TestCase as BaseTestCase;
+use Watson\Breadcrumbs\ServiceProvider;
+
+abstract class TestCase extends BaseTestCase
+{
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'testbench');
+
+        $app['config']->set('database.connections.testbench', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [ServiceProvider::class];
+    }
+}

--- a/tests/Unit/CrumbTest.php
+++ b/tests/Unit/CrumbTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Watson\Breadcrumbs\Tests;
+namespace Watson\Breadcrumbs\Tests\Unit;
 
 use Watson\Breadcrumbs\Crumb;
 

--- a/tests/Unit/Exceptions/DefinitionAlreadyExistsExceptionTest.php
+++ b/tests/Unit/Exceptions/DefinitionAlreadyExistsExceptionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Watson\Breadcrumbs\Tests\Exceptions;
+namespace Watson\Breadcrumbs\Tests\Unit\Exceptions;
 
 use Watson\Breadcrumbs\Exceptions\DefinitionAlreadyExistsException;
-use Watson\Breadcrumbs\Tests\TestCase;
+use Watson\Breadcrumbs\Tests\Unit\TestCase;
 
 class DefinitionAlreadyExistsExceptionTest extends TestCase
 {

--- a/tests/Unit/Exceptions/DefinitionNotFoundExceptionTest.php
+++ b/tests/Unit/Exceptions/DefinitionNotFoundExceptionTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Watson\Breadcrumbs\Tests\Exceptions;
+namespace Watson\Breadcrumbs\Tests\Unit\Exceptions;
 
 use Watson\Breadcrumbs\Exceptions\DefinitionNotFoundException;
-use Watson\Breadcrumbs\Tests\TestCase;
+use Watson\Breadcrumbs\Tests\Unit\TestCase;
 
 class DefinitionNotFoundExceptionTest extends TestCase
 {

--- a/tests/Unit/ManagerTest.php
+++ b/tests/Unit/ManagerTest.php
@@ -52,7 +52,7 @@ class ManagerTest extends TestCase
 
         $this->generator->shouldReceive('generate')
             ->once()
-            ->with($route)
+            ->with('home', [])
             ->andReturn($breadcrumbs);
 
         $this->renderer->shouldReceive('render')

--- a/tests/Unit/ManagerTest.php
+++ b/tests/Unit/ManagerTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Watson\Breadcrumbs\Tests;
+namespace Watson\Breadcrumbs\Tests\Unit;
 
-use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Routing\Route;
 use Illuminate\Support\HtmlString;
-use Illuminate\View\Factory;
 use Mockery;
 use Watson\Breadcrumbs\Generator;
 use Watson\Breadcrumbs\Manager;
-use Watson\Breadcrumbs\Route;
+use Watson\Breadcrumbs\Renderer;
 
 class ManagerTest extends TestCase
 {
@@ -18,11 +18,11 @@ class ManagerTest extends TestCase
     {
         parent::setUp();
 
-        $this->view = Mockery::mock(Factory::class);
-        $this->config = Mockery::mock(Repository::class);
+        $this->router = Mockery::mock(Registrar::class);
         $this->generator = Mockery::mock(Generator::class);
+        $this->renderer = Mockery::mock(Renderer::class);
 
-        $this->breadcrumbs = new Manager($this->view, $this->config, $this->generator);
+        $this->breadcrumbs = new Manager($this->router, $this->generator, $this->renderer);
     }
 
     /** @test */
@@ -40,20 +40,24 @@ class ManagerTest extends TestCase
     }
 
     /** @test */
-    function it_renders_the_correct_view_with_breadcrumbs()
+    function it_renders_with_the_current_route()
     {
+        $route = new Route('GET', '/', ['as' =>'home']);
+
+        $this->router->shouldReceive('current')
+            ->once()
+            ->andReturn($route);
+
+        $breadcrumbs = collect([1, 2, 3]);
+
         $this->generator->shouldReceive('generate')
             ->once()
-            ->andReturn(collect([1, 2, 3]));
+            ->with($route)
+            ->andReturn($breadcrumbs);
 
-        $this->config->shouldReceive('get')
-            ->with('breadcrumbs.view')
+        $this->renderer->shouldReceive('render')
             ->once()
-            ->andReturn('index.html');
-
-        $this->view->shouldReceive('make')
-            ->with('index.html', ['breadcrumbs' => collect([1, 2, 3])])
-            ->once()
+            ->with($breadcrumbs)
             ->andReturn(new HtmlString('foo'));
 
         $result = $this->breadcrumbs->render();

--- a/tests/Unit/RegistrarTest.php
+++ b/tests/Unit/RegistrarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Watson\Breadcrumbs\Tests;
+namespace Watson\Breadcrumbs\Tests\Unit;
 
 use Watson\Breadcrumbs\Registrar;
 use Watson\Breadcrumbs\Exceptions\DefinitionNotFoundException;

--- a/tests/Unit/RendererTest.php
+++ b/tests/Unit/RendererTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Watson\Breadcrumbs\Tests\Unit;
+
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Support\HtmlString;
+use Mockery;
+use Watson\Breadcrumbs\Renderer;
+
+class RendererTest extends TestCase
+{
+    protected $renderer;
+
+    function setUp(): void
+    {
+        parent::setUp();
+
+        $this->view = Mockery::mock(Factory::class);
+        $this->config = Mockery::mock(Repository::class);
+
+        $this->renderer = new Renderer($this->view, $this->config);
+    }
+
+    /** @test */
+    function it_renders_the_correct_view_with_breadcrumbs()
+    {
+        $this->config->shouldReceive('get')
+            ->with('breadcrumbs.view')
+            ->once()
+            ->andReturn('index.html');
+
+        $this->view->shouldReceive('make')
+            ->with('index.html', ['breadcrumbs' => collect([1, 2, 3])])
+            ->once()
+            ->andReturn(new HtmlString('foo'));
+
+        $result = $this->renderer->render(collect([1, 2, 3]));
+
+        $this->assertEquals('foo', $result->toHtml());
+        $this->assertInstanceOf(HtmlString::class, $result);
+    }
+}

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Watson\Breadcrumbs\Tests;
+namespace Watson\Breadcrumbs\Tests\Unit;
 
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase as BaseTestCase;


### PR DESCRIPTION
This PR is working on a new major release of breadcrumbs, supporting the later versions of Laravel with a brand new API. It'll take advantage of the new improvements in Laravel and drop unnecessary complexities.

```php
Breadcrumbs::for('home', function () {
    $this->then('Home', route('home'));
});

Breadcrumbs::for('users.index', function () {
    $this->extends('home')->then('Users', route('users.index'));
});

Breadcrumbs::for('users.show', function (User $user) {
    $this->extends('users.index')->then($user->full_name, route('users.show', $user));
});
```

Some key differences:

* We don't need to pass `$trail` in as the first parameter anymore - it's bound to the context as `$this`.
* We replace `parent` and `add` with `extends` and `then` which I think are more readable - not sure yet. May keep the old names in for those with preferences.