### PR TITLE
Do not wrap parameters before passing it to generator

### DIFF
--- a/src/Breadcrumbs/Manager.php
+++ b/src/Breadcrumbs/Manager.php
@@ -66,8 +66,6 @@ class Manager
      */
     public function render($parameters = null): ?Htmlable
     {
-        $parameters = Arr::wrap($parameters);
-
         if ($breadcrumbs = $this->generator->generate($parameters)) {
             return $this->view->make($this->config->get('breadcrumbs.view'), compact('breadcrumbs'));
         }

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -44,6 +44,9 @@ class ManagerTest extends TestCase
     {
         $this->generator->shouldReceive('generate')
             ->once()
+            ->with(Mockery::on(function ($argument) {
+               return $argument === null;
+            }))
             ->andReturn(collect([1, 2, 3]));
 
         $this->config->shouldReceive('get')


### PR DESCRIPTION
Hey, great package, thanks for this. Current version on latest Laravel returns empty string all the time, and the dev-develop branch doesn't seem to work on php 7.4.6 either. Master version works, but fails as soon as I use route parameters (#11)

I noticed that the parameters are array wrapped in the render function and passed to generator as array always. The generator function then checks if it's `isset`, and if it is, it doesn't get route parameters. So I think the best course to action is to remove the wrapping in the render function. 

What do you think?

