### PR TITLE
Upgrade Laravel 8 Version Constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "illuminate/routing": "^7.0",
-        "illuminate/support": "^7.0",
-        "illuminate/view": "^7.0"
+        "illuminate/routing": "^7.0|^8.0",
+        "illuminate/support": "^7.0|^8.0",
+        "illuminate/view": "^7.0|^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",


### PR DESCRIPTION
Since this branch works with Laravel 7, I don't think anything needs to change for Laravel 8 other than the version constraint. Feel free to correct me if I'm wrong. 

This way people can keep using this branch should they choose on Laravel 8.