### PR TITLE
Laravel 6 (LTS) and 7 support for Version 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --prefer-source --no-interaction --dev
+  - travis_retry composer install --prefer-source --no-interaction
 
 script: vendor/bin/phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
     ],
     "require": {
         "php": "^7.3||^8.0",
-        "illuminate/routing": "^8.0",
-        "illuminate/support": "^8.0",
-        "illuminate/view": "^8.0"
+        "illuminate/routing": "^6.9||^7.0||^8.0",
+        "illuminate/support": "^6.9||^7.0||^8.0",
+        "illuminate/view": "^6.9||^7.0||^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4.2",
         "phpunit/phpunit": "^9.0",
-        "orchestra/testbench": "^6.1"
+        "orchestra/testbench": "^4.5||^5.0||^6.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Because Laravel 6 is the current Long Term Support  (LTS) version</abbr>

Reference: https://laravel.com/docs/8.x/releases#support-policy